### PR TITLE
ODP-706 HIVE-26953: Exception in alter partitions with oracle db when…

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -4136,7 +4136,6 @@ public class ObjectStore implements RawStore, Configurable {
 
         try (QueryWrapper query = new QueryWrapper(queryWithParams.getLeft())) {
           query.setResultClass(MPartition.class);
-          query.setClass(MPartition.class);
           query.setOrdering("partitionName ascending");
 
           List<MPartition> mparts = (List<MPartition>) query.executeWithMap(queryWithParams.getRight());
@@ -4152,7 +4151,6 @@ public class ObjectStore implements RawStore, Configurable {
     Pair<Query, Map<String, String>> queryWithParams =
         getPartQueryWithParams(catName, dbName, tblName, partNames);
     try (QueryWrapper query = new QueryWrapper(queryWithParams.getLeft())) {
-      query.setClass(MPartition.class);
       long deleted = query.deletePersistentAll(queryWithParams.getRight());
       LOG.debug("Deleted {} partition from store", deleted);
     }
@@ -4169,7 +4167,6 @@ public class ObjectStore implements RawStore, Configurable {
     Pair<Query, Map<String, String>> queryWithParams =
         getPartQueryWithParams(catName, dbName, tblName, partNames);
     try (QueryWrapper query = new QueryWrapper(queryWithParams.getLeft())) {
-      query.setClass(MPartition.class);
       query.setResult("sd");
       List<MStorageDescriptor> sds = (List<MStorageDescriptor>) query.executeWithMap(
           queryWithParams.getRight());
@@ -4218,7 +4215,7 @@ public class ObjectStore implements RawStore, Configurable {
 
   private Pair<Query, Map<String, String>> getPartQueryWithParams(
       String catName, String dbName, String tblName, List<String> partNames) {
-    Query query = pm.newQuery();
+    Query query = pm.newQuery(MPartition.class);
     Map<String, String> params = new HashMap<>();
     String filterStr = getJDOFilterStrForPartitionNames(catName, dbName, tblName, partNames, params);
     query.setFilter(filterStr);
@@ -5164,12 +5161,9 @@ public class ObjectStore implements RawStore, Configurable {
       tblName = normalizeIdentifier(tblName);
       List<MPartition> mPartitionList;
 
-      try (Query query = pm.newQuery(MPartition.class,
-              "table.tableName == t1 && table.database.name == t2 && t3.contains(partitionName) " +
-                      " && table.database.catalogName == t4")) {
-        query.declareParameters("java.lang.String t1, java.lang.String t2, java.util.Collection t3, "
-                + "java.lang.String t4");
-        mPartitionList = (List<MPartition>) query.executeWithArray(tblName, dbName, partNames, catName);
+      Pair<Query, Map<String, String>> queryWithParams = getPartQueryWithParams(catName, dbName, tblName, partNames);
+      try (QueryWrapper query = new QueryWrapper(queryWithParams.getLeft())) {
+        mPartitionList = (List<MPartition>) query.executeWithMap(queryWithParams.getRight());
         pm.retrieveAll(mPartitionList);
 
         if (mPartitionList.size() > newParts.size()) {


### PR DESCRIPTION
… partitions are more than 1000

### Why are the changes needed?
To handle updates on large partitioned tables containing more than 1000 entries for Oracle DB 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Validated using internal function suite
