### PR TITLE
ODP-1939 | HIVE-26127: INSERT OVERWRITE throws FileNotFound when destination partition is deleted

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -5370,7 +5370,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
       // But not sure why we changed not to delete the oldPath in HIVE-8750 if it is
       // not the destf or its subdir?
       isOldPathUnderDestf = isSubDir(oldPath, destPath, oldFs, destFs, false);
-      if (isOldPathUnderDestf) {
+      if (isOldPathUnderDestf && oldFs.exists(oldPath)) {
         cleanUpOneDirectoryForReplace(oldPath, oldFs, pathFilter, conf, purge, isNeedRecycle);
       }
     } catch (IOException e) {

--- a/ql/src/test/queries/clientpositive/insert_overwrite.q
+++ b/ql/src/test/queries/clientpositive/insert_overwrite.q
@@ -77,6 +77,10 @@ SELECT count(*) FROM ext_part;
 
 SELECT * FROM ext_part ORDER BY par, col;
 
+-- removing a partition manually should not fail the next insert overwrite operation
+dfs -rm -r ${hiveconf:hive.metastore.warehouse.dir}/ext_part/par=1;
+INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b;
+
 drop table ext_part;
 drop table b;
 

--- a/ql/src/test/results/clientpositive/llap/insert_overwrite.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_overwrite.q.out
@@ -308,6 +308,17 @@ POSTHOOK: Input: default@ext_part@par=2
 third	1
 first	2
 second	2
+#### A masked pattern was here ####
+PREHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@b
+PREHOOK: Output: default@ext_part
+POSTHOOK: query: INSERT OVERWRITE TABLE ext_part PARTITION (par) SELECT * FROM b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@b
+POSTHOOK: Output: default@ext_part
+POSTHOOK: Output: default@ext_part@par=1
+POSTHOOK: Lineage: ext_part PARTITION(par=1).col SIMPLE [(b)b.FieldSchema(name:par, type:string, comment:null), ]
 PREHOOK: query: drop table ext_part
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@ext_part


### PR DESCRIPTION
ODP-1939 | HIVE-26127: INSERT OVERWRITE throws FileNotFound when destination partition is deleted