### PR TITLE
ODP-3672 Missing perf logger metrics due to different session state o…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/log/PerfLogger.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/log/PerfLogger.java
@@ -119,6 +119,24 @@ public class PerfLogger {
     return result;
   }
 
+  public void mergeFrom(PerfLogger other) {
+    if (other == null) {
+      return;
+    }
+
+    // Merge startTimes
+    for (Map.Entry<String, Long> entry : other.startTimes.entrySet()) {
+      // Don't overwrite if already present
+      this.startTimes.putIfAbsent(entry.getKey(), entry.getValue());
+    }
+
+    // Merge endTimes
+    for (Map.Entry<String, Long> entry : other.endTimes.entrySet()) {
+      // Don't overwrite if already present
+      this.endTimes.putIfAbsent(entry.getKey(), entry.getValue());
+    }
+  }
+
   /**
    * Call this function when you start to measure time spent by a piece of code.
    * @param callerName the logging object to be used.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -319,6 +319,7 @@ public class TezTask extends Task<TezWork> {
         }
       }
       updateNumRows();
+      SessionState.getPerfLogger().mergeFrom(perfLogger);
     } catch (Exception e) {
       LOG.error("Failed to execute tez graph.", e);
       setException(e);


### PR DESCRIPTION
…bject initialisation

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Due to different session states creating separate private PerfLogger instances, there is an issue where both compile-time and runtime stats are not visible together. This behavior is a result of recent changes introduced in the community via [HIVE-21520](https://issues.apache.org/jira/browse/HIVE-21520).


### Why are the changes needed?
To avoid blocking observability about perfLogger through hooks


### How was this patch tested?
Tested this internally on lab where perfLogger Hook contains summary about compile and runtime stats along with accurate execution summary as maintained from earlier fixes.
<img width="1647" alt="image" src="https://github.com/user-attachments/assets/f7a9c348-c0ce-4cb6-a91b-102f2f2906b2" />
<img width="836" alt="image" src="https://github.com/user-attachments/assets/172311a0-f47b-429d-9ebf-6abf7823cc45" />


