### PR TITLE
OSV-4596 - CVE - Increasing jackson version to 2.14.1 inorder to fix CVE-2022-42003 and CVE-2022-42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>
     <ivy.version>2.5.1</ivy.version>
-    <jackson.version>2.12.7</jackson.version>
-    <jackson.version.databind>2.12.7.1</jackson.version.databind>
+    <jackson.version>2.13.5</jackson.version>
+    <jackson.version.databind>2.13.5</jackson.version.databind>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.3.1</jamon-runtime.version>
     <javaewah.version>0.3.2</javaewah.version>

--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>
     <ivy.version>2.5.1</ivy.version>
-    <jackson.version>2.13.5</jackson.version>
-    <jackson.version.databind>2.13.5</jackson.version.databind>
+    <jackson.version>2.14.1</jackson.version>
+    <jackson.version.databind>2.14.1</jackson.version.databind>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.3.1</jamon-runtime.version>
     <javaewah.version>0.3.2</javaewah.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -107,7 +107,7 @@
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.2.3.3.2.3.4-2</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
-    <jackson.version>2.13.2</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -107,7 +107,7 @@
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.2.3.3.2.3.4-2</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
-    <jackson.version>2.13.5</jackson.version>
+    <jackson.version>2.14.1</jackson.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>


### PR DESCRIPTION
OSV-4596 - CVE - Increasing jackson version to 2.14.1 inorder to fix CVE-2022-42003 and CVE-2022-42004