### PR TITLE
OSV-4596 - CVE - Increasing avatica version to 1.23.0 inorder to fix CVE-2020-11620

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->
     <arrow.version>2.0.0</arrow.version>
-    <avatica.version>1.12.0</avatica.version>
+    <avatica.version>1.23.0</avatica.version>
     <avro.version>1.11.3</avro.version>
     <bcprov-jdk15on.version>1.64</bcprov-jdk15on.version>
     <calcite.version>1.25.0</calcite.version>


### PR DESCRIPTION
Increasing avatica version to 1.23.0 inorder to fix CVE-2020-11620