### PR TITLE
OSV-4450 - CVE - Increasing parquet version to 1.13.1 inorder to fix CVE-2020-10650

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.5</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
-    <parquet.version>1.11.1</parquet.version>
+    <parquet.version>1.13.1</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
     <protobuf.version>2.5.0</protobuf.version>


### PR DESCRIPTION
 Increasing parquet version to 1.13.1 inorder to fix CVE-2020-10650