### PR TITLE
Revert "OSV-9739: Bumping json-path due to CVE (#118)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
     <jjwt.version>0.10.5</jjwt.version>
     <re2j.version>1.2</re2j.version>
     <rs-api.version>2.1.1</rs-api.version>
-    <json-path.version>3.0.0</json-path.version>
+    <json-path.version>2.9.0</json-path.version>
     <janino.version>3.0.11</janino.version>
     <datasketches.version>1.1.0-incubating</datasketches.version>
     <spotbugs.version>4.0.3</spotbugs.version>


### PR DESCRIPTION
This reverts commit 952c6dcafb68bfa9744f5fee22e7d2398952477d.
