### PR TITLE
ODP-6522|HIVE-28625 Upgrade Apache Parquet version to 1.14.4 (partial backport) and fix additional java references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.5</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
-    <parquet.version>1.13.1</parquet.version>
+    <parquet.version>1.14.4</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
     <protobuf.version>2.5.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.5</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
-    <parquet.version>1.16.0</parquet.version>
+    <parquet.version>1.13.1</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
     <protobuf.version>2.5.0</protobuf.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1051,6 +1051,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>build-exec-bundle</id>
@@ -1122,6 +1123,20 @@
                 </includes>
               </artifactSet>
               <filters>
+                <filter>
+                  <artifact>org.apache.parquet:parquet-hadoop-bundle</artifact>
+                  <excludes>
+                    <exclude>META-INF/versions/11/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
                 <filter>
                   <artifact>org.apache.calcite.avatica:avatica</artifact>
                   <excludes>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1128,6 +1128,7 @@
                   <excludes>
                     <exclude>META-INF/versions/11/**</exclude>
                     <exclude>META-INF/versions/12/**</exclude>
+                    <exclude>META-INF/versions/21/**</exclude>
                   </excludes>
                 </filter>
                 <filter>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1127,6 +1127,7 @@
                   <artifact>org.apache.parquet:parquet-hadoop-bundle</artifact>
                   <excludes>
                     <exclude>META-INF/versions/11/**</exclude>
+                    <exclude>META-INF/versions/12/**</exclude>
                   </excludes>
                 </filter>
                 <filter>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1051,7 +1051,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
         <executions>
           <execution>
             <id>build-exec-bundle</id>
@@ -1137,13 +1136,6 @@
                     <exclude>META-INF/versions/11/**</exclude>
                     <exclude>META-INF/versions/17/**</exclude>
                     <exclude>META-INF/versions/21/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/versions/**</exclude>
-                    <exclude>**/module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
This PR reverts 
OSV-9716 patch is reverted.
Additionally, HIVE-28625 Upgrade Apache Parquet version to 1.14.4 is partially backported. This fix bumps up Parquet to 1.14.4, also addressing CVE raised in OSV-9716, as Parquet 1.14.4 uses Jackson 2.17.x.
ODP-6522 also includes fixes for compilation errors arising fro multiple java version references in parquet 1.14.4.