### PR TITLE
OCR-2406 | HIVE-29613: Cross-product join falls back to single-reducer shuffle merge when small-side row estimate marginally exceeds hive.xprod.mapjoin.small.table.rows

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -1032,6 +1032,34 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
   }
 
   /**
+   * When estimated rows already exceed {@link ConfVars#XPROD_SMALL_TABLE_ROWS_THRESHOLD}, still allow
+   * cross-product map join if {@link #computeOnlineDataSize} fits within the unconditional map-join
+   * byte budget ({@link ConfVars#HIVE_CONVERT_JOIN_NOCONDITIONAL_TASK_THRESHOLD}). NDV-based cardinality
+   * can overshoot row counts on tiny tables while bytes remain broadcast-safe.
+   */
+  @VisibleForTesting
+  boolean crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(Statistics parentStats,
+      long xprodRowThreshold, long noconditionalMaxBytes) {
+    long onlineBytes = computeOnlineDataSize(parentStats);
+    if (onlineBytes <= 0) {
+      LOG.debug(
+          "Cross-product map join: row estimate {} exceeds {} but online size unavailable; not applying byte fallback",
+          parentStats.getNumRows(), xprodRowThreshold);
+      return false;
+    }
+    if (onlineBytes <= noconditionalMaxBytes) {
+      LOG.info(
+          "Cross-product map join: row estimate {} exceeds {} but online size {} within broadcast budget {}; allowing map join",
+          parentStats.getNumRows(), xprodRowThreshold, onlineBytes, noconditionalMaxBytes);
+      return true;
+    }
+    LOG.debug(
+        "Cross-product map join: row estimate {} exceeds {} and online size {} exceeds budget {}",
+        parentStats.getNumRows(), xprodRowThreshold, onlineBytes, noconditionalMaxBytes);
+    return false;
+  }
+
+  /**
    * Return result for getMapJoinConversion method.
    */
   public static class MapJoinConversion {
@@ -1251,14 +1279,21 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     boolean cartesianProductEdgeEnabled =
       HiveConf.getBoolVar(context.conf, HiveConf.ConfVars.TEZ_CARTESIAN_PRODUCT_EDGE_ENABLED);
     if (cartesianProductEdgeEnabled && !hasOuterJoin(joinOp) && isCrossProduct(joinOp)) {
+      final long xprodRowThreshold =
+          HiveConf.getIntVar(context.conf, HiveConf.ConfVars.XPROD_SMALL_TABLE_ROWS_THRESHOLD);
+      final long noconditionalBroadcastBudget =
+          HiveConf.getLongVar(context.conf, HiveConf.ConfVars.HIVE_CONVERT_JOIN_NOCONDITIONAL_TASK_THRESHOLD);
       for (int i = 0 ; i < joinOp.getParentOperators().size(); i ++) {
         if (i != bigTablePosition) {
           Statistics parentStats = joinOp.getParentOperators().get(i).getStatistics();
-          if (parentStats.getNumRows() >
-            HiveConf.getIntVar(context.conf, HiveConf.ConfVars.XPROD_SMALL_TABLE_ROWS_THRESHOLD)) {
-            // if any of smaller side is estimated to generate more than
-            // threshold rows we would disable mapjoin
-            return null;
+          if (parentStats.getNumRows() > xprodRowThreshold) {
+            // NDV-based filters often estimate a few rows on tiny lookups (e.g. 2 vs 1); row count
+            // alone can reject a safe broadcast. If estimated online size still fits the same
+            // unconditional map-join byte budget, allow conversion (same knob as noconditionaltask).
+            if (!crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(parentStats, xprodRowThreshold,
+                noconditionalBroadcastBudget)) {
+              return null;
+            }
           }
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -1032,30 +1032,32 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
   }
 
   /**
-   * When estimated rows already exceed {@link ConfVars#XPROD_SMALL_TABLE_ROWS_THRESHOLD}, still allow
-   * cross-product map join if {@link #computeOnlineDataSize} fits within the unconditional map-join
-   * byte budget ({@link ConfVars#HIVE_CONVERT_JOIN_NOCONDITIONAL_TASK_THRESHOLD}). NDV-based cardinality
+   * Byte-budget fallback applied after the row-count check in the cross-product gate of
+   * {@link #getMapJoinConversion} fails. Admits the broadcast when
+   * {@link #computeOnlineDataSize} on the small side fits the same byte budget used elsewhere
+   * in {@code getMapJoinConversion} ({@code maxSize}, which is
+   * {@link MemoryMonitorInfo#getAdjustedNoConditionalTaskSize()} on LLAP). NDV-based cardinality
    * can overshoot row counts on tiny tables while bytes remain broadcast-safe.
    */
   @VisibleForTesting
-  boolean crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(Statistics parentStats,
-      long xprodRowThreshold, long noconditionalMaxBytes) {
+  boolean crossProductBuildSideWithinBroadcastBudget(Statistics parentStats,
+      long xprodRowThreshold, long broadcastBudgetBytes) {
     long onlineBytes = computeOnlineDataSize(parentStats);
     if (onlineBytes <= 0) {
       LOG.debug(
-          "Cross-product map join: row estimate {} exceeds {} but online size unavailable; not applying byte fallback",
+          "Cross-product map join: row estimate {} exceeds {} and online size unavailable; rejecting map join",
           parentStats.getNumRows(), xprodRowThreshold);
       return false;
     }
-    if (onlineBytes <= noconditionalMaxBytes) {
+    if (onlineBytes <= broadcastBudgetBytes) {
       LOG.info(
           "Cross-product map join: row estimate {} exceeds {} but online size {} within broadcast budget {}; allowing map join",
-          parentStats.getNumRows(), xprodRowThreshold, onlineBytes, noconditionalMaxBytes);
+          parentStats.getNumRows(), xprodRowThreshold, onlineBytes, broadcastBudgetBytes);
       return true;
     }
     LOG.debug(
-        "Cross-product map join: row estimate {} exceeds {} and online size {} exceeds budget {}",
-        parentStats.getNumRows(), xprodRowThreshold, onlineBytes, noconditionalMaxBytes);
+        "Cross-product map join: row estimate {} exceeds {} and online size {} exceeds budget {}; rejecting map join",
+        parentStats.getNumRows(), xprodRowThreshold, onlineBytes, broadcastBudgetBytes);
     return false;
   }
 
@@ -1281,17 +1283,17 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
     if (cartesianProductEdgeEnabled && !hasOuterJoin(joinOp) && isCrossProduct(joinOp)) {
       final long xprodRowThreshold =
           HiveConf.getIntVar(context.conf, HiveConf.ConfVars.XPROD_SMALL_TABLE_ROWS_THRESHOLD);
-      final long noconditionalBroadcastBudget =
-          HiveConf.getLongVar(context.conf, HiveConf.ConfVars.HIVE_CONVERT_JOIN_NOCONDITIONAL_TASK_THRESHOLD);
+      // Any small side over budget disables the broadcast, so iterate all non-big parents and
+      // bail on the first failure.
       for (int i = 0 ; i < joinOp.getParentOperators().size(); i ++) {
         if (i != bigTablePosition) {
           Statistics parentStats = joinOp.getParentOperators().get(i).getStatistics();
           if (parentStats.getNumRows() > xprodRowThreshold) {
             // NDV-based filters often estimate a few rows on tiny lookups (e.g. 2 vs 1); row count
-            // alone can reject a safe broadcast. If estimated online size still fits the same
-            // unconditional map-join byte budget, allow conversion (same knob as noconditionaltask).
-            if (!crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(parentStats, xprodRowThreshold,
-                noconditionalBroadcastBudget)) {
+            // alone can reject a safe broadcast. Use the same byte budget the rest of this method
+            // already uses (maxSize == maxJoinMemory, LLAP-adjusted) so cross-product decisions
+            // stay aligned with every other map-join sizing check above.
+            if (!crossProductBuildSideWithinBroadcastBudget(parentStats, xprodRowThreshold, maxSize)) {
               return null;
             }
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -1293,7 +1293,11 @@ public class ConvertJoinMapJoin implements SemanticNodeProcessor {
             // alone can reject a safe broadcast. Use the same byte budget the rest of this method
             // already uses (maxSize == maxJoinMemory, LLAP-adjusted) so cross-product decisions
             // stay aligned with every other map-join sizing check above.
-            if (!crossProductBuildSideWithinBroadcastBudget(parentStats, xprodRowThreshold, maxSize)) {
+            // xprodRowThreshold <= 0 is treated as a hard disable of the broadcast: an operator
+            // who set the row cap to zero means "no broadcast for this shape," so skip the byte
+            // fallback and keep the strict reject.
+            if (xprodRowThreshold <= 0
+                || !crossProductBuildSideWithinBroadcastBudget(parentStats, xprodRowThreshold, maxSize)) {
               return null;
             }
           }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hadoop.hive.ql.plan.Statistics;
+import org.junit.jupiter.api.Test;
+
+class TestConvertJoinMapJoin {
+
+  @Test
+  void crossProductByteFallback_allowsWhenOnlineSizeWithinBudget() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(2L, 500L, 0L, 0L);
+    assertTrue(
+        converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 10_000_000L));
+  }
+
+  @Test
+  void crossProductByteFallback_rejectsWhenOnlineSizeExceedsBudget() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(50_000L, 50_000_000L, 0L, 0L);
+    assertFalse(
+        converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 10_000_000L));
+  }
+
+  @Test
+  void crossProductByteFallback_rejectsWhenBudgetTooSmallForEstimatedSize() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(2L, 500L, 0L, 0L);
+    assertFalse(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 1L));
+  }
+
+  /**
+   * NDV-driven filter selectivity can estimate a tiny lookup at ~2 rows / a few hundred bytes
+   * onlineDataSize when {@code hive.xprod.mapjoin.small.table.rows=1}. The row-only gate would
+   * reject the broadcast even though the build side is well below the noconditionaltask byte
+   * budget. The byte fallback must still admit map-join in that shape.
+   */
+  @Test
+  void crossProductByteFallback_twoRowsTinyOnlineSize() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    final long ndvDrivenRowEstimate = 2L;
+    final long tinyDataSizeBytes = 296L;
+    Statistics stats = new Statistics(ndvDrivenRowEstimate, tinyDataSizeBytes, 0L, 0L);
+    final long xprodRowThreshold = 1L;
+    final long noconditionalBudgetBytes = 10_000_000L;
+    assertTrue(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(
+        stats, xprodRowThreshold, noconditionalBudgetBytes));
+  }
+
+  /**
+   * Same small row estimate (2) as the previous case, but with bytes large enough that the build
+   * side exceeds the broadcast budget — the byte fallback must reject so the row-only cap still
+   * bites.
+   */
+  @Test
+  void crossProductByteFallback_rejectsTwoRowsWhenEstimatedPayloadExceedsBudget() {
+    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
+    converter.hashTableLoadFactor = 0.75f;
+    Statistics stats = new Statistics(2L, 50_000_000L, 0L, 0L);
+    assertFalse(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(
+        stats, 1L, 10_000_000L));
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
@@ -106,4 +106,24 @@ class TestConvertJoinMapJoin {
     }
     assertFalse(allWithinBudget);
   }
+
+  /**
+   * Pins the hard-disable semantics for {@code xprodRowThreshold <= 0}: the caller short-circuits
+   * the byte fallback when the operator has zeroed the row cap, so a stats shape that would
+   * otherwise fit the broadcast budget must still reject. Mirrors the caller guard in
+   * {@code getMapJoinConversion} so a future refactor that drops the guard fails here.
+   */
+  @Test
+  void crossProductByteFallback_rejectsWhenRowThresholdZero() {
+    ConvertJoinMapJoin converter = newConverter();
+    final long xprodRowThreshold = 0L;
+    final long broadcastBudgetBytes = 10_000_000L;
+    Statistics stats = new Statistics(2L, 500L, 0L, 0L);
+
+    boolean allowed = stats.getNumRows() > xprodRowThreshold
+        && xprodRowThreshold > 0L
+        && converter.crossProductBuildSideWithinBroadcastBudget(
+            stats, xprodRowThreshold, broadcastBudgetBytes);
+    assertFalse(allowed);
+  }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/TestConvertJoinMapJoin.java
@@ -26,30 +26,30 @@ import org.junit.jupiter.api.Test;
 
 class TestConvertJoinMapJoin {
 
-  @Test
-  void crossProductByteFallback_allowsWhenOnlineSizeWithinBudget() {
+  private static ConvertJoinMapJoin newConverter() {
     ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
     converter.hashTableLoadFactor = 0.75f;
+    return converter;
+  }
+
+  @Test
+  void crossProductByteFallback_allowsWhenOnlineSizeWithinBudget() {
     Statistics stats = new Statistics(2L, 500L, 0L, 0L);
     assertTrue(
-        converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 10_000_000L));
+        newConverter().crossProductBuildSideWithinBroadcastBudget(stats, 1L, 10_000_000L));
   }
 
   @Test
   void crossProductByteFallback_rejectsWhenOnlineSizeExceedsBudget() {
-    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
-    converter.hashTableLoadFactor = 0.75f;
     Statistics stats = new Statistics(50_000L, 50_000_000L, 0L, 0L);
     assertFalse(
-        converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 10_000_000L));
+        newConverter().crossProductBuildSideWithinBroadcastBudget(stats, 1L, 10_000_000L));
   }
 
   @Test
   void crossProductByteFallback_rejectsWhenBudgetTooSmallForEstimatedSize() {
-    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
-    converter.hashTableLoadFactor = 0.75f;
     Statistics stats = new Statistics(2L, 500L, 0L, 0L);
-    assertFalse(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(stats, 1L, 1L));
+    assertFalse(newConverter().crossProductBuildSideWithinBroadcastBudget(stats, 1L, 1L));
   }
 
   /**
@@ -60,15 +60,13 @@ class TestConvertJoinMapJoin {
    */
   @Test
   void crossProductByteFallback_twoRowsTinyOnlineSize() {
-    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
-    converter.hashTableLoadFactor = 0.75f;
     final long ndvDrivenRowEstimate = 2L;
     final long tinyDataSizeBytes = 296L;
     Statistics stats = new Statistics(ndvDrivenRowEstimate, tinyDataSizeBytes, 0L, 0L);
     final long xprodRowThreshold = 1L;
-    final long noconditionalBudgetBytes = 10_000_000L;
-    assertTrue(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(
-        stats, xprodRowThreshold, noconditionalBudgetBytes));
+    final long broadcastBudgetBytes = 10_000_000L;
+    assertTrue(newConverter().crossProductBuildSideWithinBroadcastBudget(
+        stats, xprodRowThreshold, broadcastBudgetBytes));
   }
 
   /**
@@ -78,10 +76,34 @@ class TestConvertJoinMapJoin {
    */
   @Test
   void crossProductByteFallback_rejectsTwoRowsWhenEstimatedPayloadExceedsBudget() {
-    ConvertJoinMapJoin converter = new ConvertJoinMapJoin();
-    converter.hashTableLoadFactor = 0.75f;
     Statistics stats = new Statistics(2L, 50_000_000L, 0L, 0L);
-    assertFalse(converter.crossProductBuildSideWithinBroadcastBudgetAfterRowCheck(
+    assertFalse(newConverter().crossProductBuildSideWithinBroadcastBudget(
         stats, 1L, 10_000_000L));
+  }
+
+  /**
+   * Pins the caller-side contract: {@code getMapJoinConversion} iterates every non-big parent
+   * and rejects the whole broadcast on the first small side that fails the helper. Simulating
+   * that loop here means any future refactor that lets a single safe side mask an unsafe sibling
+   * will fail this test.
+   */
+  @Test
+  void crossProductByteFallback_anySmallSideOverBudgetRejectsBroadcast() {
+    ConvertJoinMapJoin converter = newConverter();
+    final long xprodRowThreshold = 1L;
+    final long broadcastBudgetBytes = 10_000_000L;
+    Statistics safeSide = new Statistics(2L, 500L, 0L, 0L);
+    Statistics oversizedSide = new Statistics(50_000L, 50_000_000L, 0L, 0L);
+
+    boolean allWithinBudget = true;
+    for (Statistics smallSide : new Statistics[] {safeSide, oversizedSide}) {
+      if (smallSide.getNumRows() > xprodRowThreshold
+          && !converter.crossProductBuildSideWithinBroadcastBudget(
+              smallSide, xprodRowThreshold, broadcastBudgetBytes)) {
+        allWithinBudget = false;
+        break;
+      }
+    }
+    assertFalse(allWithinBudget);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Widen the cross-product gate in ConvertJoinMapJoin#getMapJoinConversion: when the smaller (broadcast-candidate) side's row count exceeds hive.xprod.mapjoin.small.table.rows but its onlineDataSize still fits hive.auto.convert.join.noconditionaltask.size, allow conversion to a broadcast map-join via a new helper crossProductBuildSideWithinBroadcastBudgetAfterRowCheck. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The current gate consults only the row count of the smaller (broadcast-candidate) side. NDV-driven filter selectivity routinely estimates tiny lookups at 2–3 rows even when their actual byte footprint is a few hundred bytes — well within the broadcast budget. The gate rejects these safe broadcasts, the join falls back to a MERGEJOIN with XPROD_EDGE inputs, and the keyless shuffle collapses onto a single reducer that materialises the entire Cartesian. See [HIVE-29613](https://issues.apache.org/jira/browse/HIVE-29613) for full analysis.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Query results are unchanged. Although, For cross-product joins where the small side overshoots the row threshold but still fits the broadcast byte budget, EXPLAIN now shows MAPJOIN with BROADCAST_EDGE instead of MERGEJOIN with XPROD_EDGE on a Reducer.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Added Five new unit tests in TestConvertJoinMapJoin class