### PR TITLE
OCR-2033: HIVE-29378 filter get_tables by names to fix StackOverflow …

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -6367,15 +6367,16 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     try {
       ret = getMS().getTables(parsedDbName[CAT_NAME], parsedDbName[DB_NAME], pattern);
-      if(ret !=  null && !ret.isEmpty()) {
-        List<Table> tableInfo = new ArrayList<>();
-        tableInfo = getMS().getTableObjectsByName(parsedDbName[CAT_NAME], parsedDbName[DB_NAME], ret);
-        tableInfo = FilterUtils.filterTablesIfEnabled(isServerFilterEnabled, filterHook, tableInfo);// tableInfo object has the owner information of the table which is being passed to FilterUtils.
-        ret = new ArrayList<>();
-        for (Table tbl : tableInfo) {
-          ret.add(tbl.getTableName());
-        }
-      }
+      // HIVE-29378: Filter by name only. HiveMetaStoreAuthorizer (Ranger) and other
+      // MetaStoreFilterHook impls decide from dbName+tableName + user context; the prior
+      // getTableObjectsByName + filterTablesIfEnabled(fullTables) path materialised every
+      // Table object in the DB (unbatched -- it also StackOverflowed DataNucleus in
+      // ExpressionCompiler.compileOrAndExpression at 100k+ tables) and each convertToTable
+      // adds 5-10ms per table. HIVE-28292 rerouted HS2 SHOW TABLES around this call site
+      // but any non-HS2 caller (HCatalog, Impala, older HS2 vs newer HMS) still trips it.
+      // Matches get_all_tables() and get_tables_by_type() which already filter names only.
+      ret = FilterUtils.filterTableNamesIfEnabled(isServerFilterEnabled, filterHook,
+          parsedDbName[CAT_NAME], parsedDbName[DB_NAME], ret);
     } catch (Exception e) {
       ex = e;
       throw newMetaException(e);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestFilterHooks.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestFilterHooks.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.CompactionType;
@@ -36,6 +37,7 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.TableMeta;
+import org.apache.hadoop.hive.metastore.events.PreEventContext;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
@@ -174,6 +176,90 @@ public class TestFilterHooks {
         return new ArrayList<>();
       }
       return dcList;
+    }
+  }
+
+  /**
+   * HIVE-29378 regression guard helper. Passthrough filter hook that records which of
+   * the two SHOW TABLES filter entry points was invoked on the server. After the
+   * HMSHandler.get_tables() fix, this handler must be reached via filterTableNames only.
+   * If a regression re-introduces the pre-fix getTableObjectsByName + filterTables path,
+   * filterTablesCalls will be non-zero and the assertion fires. Serves as a proxy for
+   * the un-batched-IN-clause StackOverflow that used to hit at 100k+ tables under
+   * server-side filtering (see HIVE-29378, HIVE-24769).
+   */
+  public static class MethodRecordingFilterHook extends DefaultMetaStoreFilterHookImpl {
+    public static final AtomicInteger filterTablesCalls = new AtomicInteger();
+    public static final AtomicInteger filterTableNamesCalls = new AtomicInteger();
+
+    public MethodRecordingFilterHook(Configuration conf) { super(conf); }
+
+    public static void reset() {
+      filterTablesCalls.set(0);
+      filterTableNamesCalls.set(0);
+    }
+
+    @Override
+    public List<Table> filterTables(List<Table> tableList) throws MetaException {
+      filterTablesCalls.incrementAndGet();
+      return tableList;
+    }
+
+    @Override
+    public List<String> filterTableNames(String catName, String dbName, List<String> tableList)
+        throws MetaException {
+      filterTableNamesCalls.incrementAndGet();
+      return tableList;
+    }
+  }
+
+  /**
+   * Pre-event listener that counts PreReadTableEvent invocations. HMSHandler fires
+   * PreReadTableEvent only from getTableInternal (get_table for a single table);
+   * neither get_tables nor get_table_objects_by_name_req should fire it. If a
+   * regression starts firing per-table events during SHOW TABLES, every listener in
+   * the chain (StorageBasedAuthorizationProvider, Atlas hook, ...) runs N times --
+   * the 121k HDFS-check storm observed at the customer.
+   */
+  public static class CountingPreEventListener extends MetaStorePreEventListener {
+    public static final AtomicInteger tableReadEvents = new AtomicInteger();
+
+    public CountingPreEventListener(Configuration config) { super(config); }
+
+    @Override
+    public void onEvent(PreEventContext context) {
+      if (context.getEventType() == PreEventContext.PreEventType.READ_TABLE) {
+        tableReadEvents.incrementAndGet();
+      }
+    }
+  }
+
+  /**
+   * Behavioural boundary marker for HIVE-29378. Its filterTables(List<Table>) rejects
+   * everything because it consults Table.owner; its filterTableNames(cat, db, names) is
+   * passthrough. After the fix, HMSHandler.get_tables() invokes filterTableNames only,
+   * so this hook lets all names through -- the test locks that in as the documented
+   * contract. Downstream hook authors whose filterTables() consults Table.owner MUST
+   * replicate that logic in filterTableNames() to keep SHOW TABLES filtering intact.
+   */
+  public static class OwnerBasedFilterHook extends DefaultMetaStoreFilterHookImpl {
+    public OwnerBasedFilterHook(Configuration conf) { super(conf); }
+
+    @Override
+    public List<Table> filterTables(List<Table> tableList) throws MetaException {
+      List<Table> keep = new ArrayList<>();
+      for (Table t : tableList) {
+        if ("keep".equals(t.getOwner())) {
+          keep.add(t);
+        }
+      }
+      return keep;
+    }
+
+    @Override
+    public List<String> filterTableNames(String catName, String dbName, List<String> tableList)
+        throws MetaException {
+      return tableList;
     }
   }
 
@@ -492,5 +578,109 @@ public class TestFilterHooks {
   protected void testFilterForDataConnector() throws Exception {
     assertNotNull(client.getDataConnector(DCNAME1));
     assertEquals(0, client.getAllDataConnectorNames().size());
+  }
+
+  // ---------------------------------------------------------------------------
+  // HIVE-29378 regression guards.
+  //
+  // HIVE-24769 (fixed 4.0.0-alpha-1) made HMSHandler.get_tables() fetch full Table
+  // objects so filter hooks could authorize on Table.owner. That path calls
+  // getTableObjectsByName(cat, db, allNames) UN-BATCHED, and DataNucleus builds a
+  // recursive OR/AND expression tree from the huge IN clause; at 100k+ tables it
+  // StackOverflows in ExpressionCompiler.compileOrAndExpression, and even below
+  // that limit each convertToTable adds 5-10 ms per table (HIVE-29378).
+  //
+  // HIVE-28292 (fixed 4.1.0) rerouted HS2 SHOW TABLES away from get_tables() via
+  // listTableNamesByFilter, but left the get_tables() body intact -- so non-HS2
+  // Thrift callers (HCatalog, Impala, older HS2 vs newer HMS) still trip the bug.
+  //
+  // The fix in this branch replaces the getTableObjectsByName + filterTables block
+  // with filterTableNamesIfEnabled, matching get_all_tables() and get_tables_by_type().
+  // The three tests below defend that fix.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * HIVE-29378 StackOverflow regression guard. Asserts the server-side filter path
+   * for get_tables() goes through filterTableNames() and never through
+   * filterTables(List<Table>). Any regression that re-introduces the
+   * getTableObjectsByName(cat, db, allNames) call also re-introduces the
+   * filterTables call, so this test fires immediately and deterministically -- no
+   * 100k-table seeding required.
+   */
+  @Test
+  public void testGetTablesWithServerFilterDoesNotFetchFullTableObjects() throws Exception {
+    MetastoreConf.setBoolVar(conf, ConfVars.METASTORE_CLIENT_FILTER_ENABLED, false);
+    MetastoreConf.setBoolVar(conf, ConfVars.METASTORE_SERVER_FILTER_ENABLED, true);
+    MetastoreConf.setClass(conf, ConfVars.FILTER_HOOK,
+        MethodRecordingFilterHook.class, MetaStoreFilterHook.class);
+    DBNAME1 = "db_testGetTablesNoFullFetch_1";
+    DBNAME2 = "db_testGetTablesNoFullFetch_2";
+    creatEnv(conf);
+
+    MethodRecordingFilterHook.reset();
+    client.getTables(DBNAME1, "*");
+    assertEquals("HIVE-29378: HMSHandler.get_tables() must filter names only. "
+            + "Any filterTables(List<Table>) call from this path means the un-batched "
+            + "getTableObjectsByName(cat, db, allNames) has been re-introduced -- "
+            + "StackOverflow at 100k+ tables and 5-10ms convertToTable per table are back.",
+        0, MethodRecordingFilterHook.filterTablesCalls.get());
+    assertEquals(1, MethodRecordingFilterHook.filterTableNamesCalls.get());
+  }
+
+  /**
+   * SHOW TABLES must not fire PreReadTableEvent per table. HMSHandler fires
+   * PreReadTableEvent only from getTableInternal (single-table get_table). Any
+   * regression that starts firing per-table events during bulk listing causes the
+   * full pre-event listener chain (StorageBasedAuthorizationProvider et al.) to
+   * run N times -- the 121k HDFS-check storm observed at the customer.
+   */
+  @Test
+  public void testGetTablesDoesNotFireReadTableEventPerTable() throws Exception {
+    MetastoreConf.setBoolVar(conf, ConfVars.METASTORE_CLIENT_FILTER_ENABLED, false);
+    MetastoreConf.setClass(conf, ConfVars.PRE_EVENT_LISTENERS,
+        CountingPreEventListener.class, MetaStorePreEventListener.class);
+    DBNAME1 = "db_testNoPerTableEvent_1";
+    DBNAME2 = "db_testNoPerTableEvent_2";
+    DummyMetaStoreFilterHookImpl.blockResults = false;
+    try {
+      creatEnv(conf);
+      CountingPreEventListener.tableReadEvents.set(0);
+      client.getTables(DBNAME1, "*");
+      assertEquals("SHOW TABLES must not fire PreReadTableEvent per table "
+              + "(each event triggers the full pre-event listener chain, including "
+              + "per-table HDFS auth checks -- the customer's 121k-event storm).",
+          0, CountingPreEventListener.tableReadEvents.get());
+    } finally {
+      DummyMetaStoreFilterHookImpl.blockResults = true;
+    }
+  }
+
+  /**
+   * Behavioural boundary marker for HIVE-29378. Pre-fix get_tables() routed through
+   * filterTables(List<Table>); post-fix it routes through filterTableNames(). Hooks
+   * whose two filter methods return different results (e.g. a custom hook reading
+   * Table.owner in filterTables) will now see the filterTableNames result. This
+   * test locks the contract in:
+   *
+   *   OwnerBasedFilterHook.filterTables() would drop both TAB1 and TAB2 (owners
+   *   != "keep"). Post-fix that method is never called from get_tables(), so both
+   *   names come back. Downstream hook authors that need owner-based filtering in
+   *   bulk listing MUST replicate the logic in filterTableNames().
+   */
+  @Test
+  public void testGetTablesFilterHookContractIsFilterTableNames() throws Exception {
+    MetastoreConf.setBoolVar(conf, ConfVars.METASTORE_CLIENT_FILTER_ENABLED, false);
+    MetastoreConf.setBoolVar(conf, ConfVars.METASTORE_SERVER_FILTER_ENABLED, true);
+    MetastoreConf.setClass(conf, ConfVars.FILTER_HOOK, OwnerBasedFilterHook.class,
+        MetaStoreFilterHook.class);
+    DBNAME1 = "db_testOwnerContract_1";
+    DBNAME2 = "db_testOwnerContract_2";
+    creatEnv(conf);
+
+    List<String> names = client.getTables(DBNAME1, "*");
+    assertEquals("Post-fix get_tables() uses filterTableNames() not filterTables(); "
+            + "OwnerBasedFilterHook drops tables in filterTables() but is passthrough in "
+            + "filterTableNames(), so both seeded tables must come back.",
+        2, names.size());
   }
 }


### PR DESCRIPTION
…and per-table cost

HMSHandler.get_tables() fetched full Table objects via un-batched getTableObjectsByName(cat, db, allNames) so the filter hook could see Table.owner (HIVE-24769). At 100k+ tables that call StackOverflows in DataNucleus ExpressionCompiler.compileOrAndExpression while building the recursive OR/AND tree for the huge IN clause -- the client sees TTransportException("Socket is closed by peer"). Below that threshold each convertToTable adds 5-10 ms per table (HIVE-29378).

HIVE-28292 rerouted HS2 SHOW TABLES around this call site via listTableNamesByFilter, but any non-HS2 Thrift caller (HCatalog, Impala, older HS2 vs newer HMS) still trips it. Replace the block with a single FilterUtils.filterTableNamesIfEnabled call, matching what get_all_tables() and get_tables_by_type() already do.

HiveMetaStoreAuthorizer.filterTables and filterTableNames both build TablePrivilegeLookup from dbName+tableName only, so the Ranger case is behaviour-preserving. Custom hooks whose filterTables consults Table.owner in bulk listing must replicate the logic in filterTableNames -- new test locks that contract in as an explicit boundary marker.

Lab measurements (multi-celeborn cluster, 121001 tables in default, show tables end-to-end via beeline):

  unpatched, no server filter          ~95 s
  patched,   no server filter          2.58 - 3.59 s
  unpatched, server filter enabled     fails (StackOverflow)
  patched,   server filter enabled     2.63 - 3.57 s

Tests added in TestFilterHooks:
- testGetTablesWithServerFilterDoesNotFetchFullTableObjects: deterministic StackOverflow regression guard, asserts get_tables() goes through filterTableNames() and never filterTables(). No 100k seeding required.
- testGetTablesDoesNotFireReadTableEventPerTable: guards against per-table PreReadTableEvent storm (the customer's 121k HDFS-check bomb via StorageBasedAuthorizationProvider).
- testGetTablesFilterHookContractIsFilterTableNames: behavioural boundary marker for the filterTables -> filterTableNames contract change on the bulk-listing path.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
