### PR TITLE
OSV-21155: Bump netty.version 4.1.116.Final -> 4.1.135.Final (addresses netty 4.1.132 CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
     <mockito-core.version>5.17.0</mockito-core.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <mina.version>2.0.0-M5</mina.version>
-    <netty.version>4.1.116.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <netty3.version>3.10.5.Final</netty3.version>
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.8</pac4j-saml.version>


### PR DESCRIPTION
## Summary
- Bump `netty.version` **4.1.116.Final → 4.1.135.Final** in `pom.xml`.
- Addresses Hive OSV tickets filed against **netty 4.1.132.Final** (fix threshold 4.1.133.Final; 4.1.135.Final covers them).

## Tickets
OSV-21155, OSV-21156, OSV-21157, OSV-21158, OSV-21159, OSV-21160, OSV-21161, OSV-21184, OSV-21254, OSV-21255, OSV-21257, OSV-21259

## Note
- Excludes OSV-21258 (`grpc-netty-shaded`) — separate artifact/line.
