### PR TITLE
OSV-21153 - CVE - Bumped-up Jackson to 2.18.6 to address GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <httpcomponents.core.version>4.4.13</httpcomponents.core.version>
     <immutables.version>2.9.2</immutables.version>
     <ivy.version>2.5.2</ivy.version>
-    <jackson.version>2.16.1</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <jamon.plugin.version>2.3.4</jamon.plugin.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <javax-servlet.version>3.1.0</javax-servlet.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -97,7 +97,7 @@
     <guava.version>31.1-jre</guava.version>
     <hadoop.version>3.3.6.${odp.release.version}</hadoop.version>
     <hikaricp.version>4.0.3</hikaricp.version>
-    <jackson.version>2.16.1</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <jexl.version>3.3</jexl.version>
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-21153