### PR TITLE
OSV-21150 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-exec.version>1.1</commons-exec.version>
     <commons-io.version>2.16.1</commons-io.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <commons-text.version>1.10.0</commons-text.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -77,7 +77,7 @@
     <!-- Dependency versions -->
     <antlr.version>4.9.3</antlr.version>
     <apache-directory-server.version>2.0.0-M24</apache-directory-server.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <datasketches.version>2.0.0</datasketches.version>


### PR DESCRIPTION
- Library : commons-lang3
- Version : -> 3.18.0
- Tickets : OSV-21150