### PR TITLE
OSV-21258 - CVE - Bumped-up grpc-netty-shaded to 1.75.0 to address CVE-2025-55163

### DIFF
--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -111,7 +111,7 @@
     <protobuf.version>3.25.5</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>
-    <io.grpc.version>1.72.0</io.grpc.version>
+    <io.grpc.version>1.75.0</io.grpc.version>
     <sqlline.version>1.9.0</sqlline.version>
     <jline.version>2.14.6</jline.version>
     <ST4.version>4.0.4</ST4.version>


### PR DESCRIPTION
- Library : grpc-netty-shaded
- Version : -> 1.75.0
- Tickets : OSV-21258