### PR TITLE
OSV-21252 - CVE - Bumped-up async-http-client to 3.0.10 to address CVE-2026-40490

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
     <project.build.outputTimestamp>2025-01-01T00:00:00Z</project.build.outputTimestamp>
       <aircompressor.version>2.0.3</aircompressor.version>
         <commons-configuration2.version>2.15.0</commons-configuration2.version>
+      <async-http-client.version>3.0.10</async-http-client.version>
   </properties>
   <repositories>
     <!-- This needs to be removed before checking in-->
@@ -314,6 +315,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
         <version>2.15.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>3.0.10</version>
       </dependency>
 
       <!-- dependencies are always listed in sorted order by groupId, artifactId -->


### PR DESCRIPTION
- Library : async-http-client
- Version : -> 3.0.10
- Tickets : OSV-21252, OSV-21253