### PR TITLE
OSV-21268 - CVE - Bumped-up aircompressor to 2.0.3 to address CVE-2025-67721

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
     <spring.version>5.3.39</spring.version>
     <spring.ldap.version>2.4.4</spring.ldap.version>
     <project.build.outputTimestamp>2025-01-01T00:00:00Z</project.build.outputTimestamp>
+      <aircompressor.version>2.0.3</aircompressor.version>
   </properties>
   <repositories>
     <!-- This needs to be removed before checking in-->
@@ -1494,6 +1495,12 @@
         <artifactId>postgresql</artifactId>
         <version>${postgres.version}</version>
         <scope>runtime</scope>
+      </dependency>
+    
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>aircompressor</artifactId>
+        <version>2.0.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- Library : aircompressor
- Version : -> 2.0.3
- Tickets : OSV-21268