### PR TITLE
ODP-7275: Revert "OSV-17489 - CVE - Upgrade parquet version to 1.16.0 in order to increase jackson version to higher (#166)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <!-- used by druid storage handler -->
     <pac4j-saml.version>4.5.5</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
-    <parquet.version>1.16.0</parquet.version>
+    <parquet.version>1.14.4</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
     <protobuf.version>2.5.0</protobuf.version>


### PR DESCRIPTION
Test cluster: http://10.42.14.20:8080/


This was initially failing for `Caused by: java.lang.NoClassDefFoundError: org/locationtech/jts/io/ParseException` but even if we add that it will then fail with `Caused by: java.lang.NoSuchMethodError: org.apache.hadoop.fs.FutureDataInputStreamBuilder.withFileStatus(Lorg/apache/hadoop/fs/FileStatus;)Lorg/apache/hadoop/fs/FutureDataInputStreamBuilder;` Which is present in Hadoop 3.3.x (https://github.com/apache/hadoop/pull/2584)

Hence we will need to revert this.