### PR TITLE
OCR-2541: Fix open-txn HWM drop and gap-fill after empty TXNS cleanup

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestTxnHandler.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.hive.metastore.api.CreationMetadata;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
 import org.apache.hadoop.hive.metastore.api.GetOpenTxnsInfoResponse;
 import org.apache.hadoop.hive.metastore.api.GetOpenTxnsResponse;
+import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsRequest;
+import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsResponse;
 import org.apache.hadoop.hive.metastore.api.HeartbeatRequest;
 import org.apache.hadoop.hive.metastore.api.LockComponent;
 import org.apache.hadoop.hive.metastore.api.LockLevel;
@@ -58,6 +60,7 @@ import org.apache.hadoop.hive.metastore.api.ShowLocksResponse;
 import org.apache.hadoop.hive.metastore.api.ShowLocksResponseElement;
 import org.apache.hadoop.hive.metastore.api.SourceTable;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.TableValidWriteIds;
 import org.apache.hadoop.hive.metastore.api.TxnAbortedException;
 import org.apache.hadoop.hive.metastore.api.TxnInfo;
 import org.apache.hadoop.hive.metastore.api.TxnOpenException;
@@ -247,6 +250,131 @@ public class TestTxnHandler {
       Assert.assertEquals("No such transaction " + JavaUtils.txnIdToString(4), ex.getMessage());
     }
     Assert.assertTrue(gotException);
+  }
+
+  /**
+   * OCR-2541 / HIVE-23048: after committed empty TXNS cleanup (or if TXNS rows are removed while
+   * TXN_TO_WRITE_ID remains), open-txn HWM must still cover allocated write txn ids so
+   * getValidWriteIds does not collapse to writeIdList ...:1:1:1:.
+   */
+  @Test
+  public void testOpenTxnHwmSurvivesEmptyCommittedCleanup() throws Exception {
+    String dbName = "default";
+    String tableName = "ocr2541_hwm";
+
+    OpenTxnsResponse opened = txnHandler.openTxns(new OpenTxnRequest(3, "me", "localhost"));
+    List<Long> txnIds = opened.getTxn_ids();
+    long maxTxnId = Collections.max(txnIds);
+
+    AllocateTableWriteIdsRequest alloc = new AllocateTableWriteIdsRequest(dbName, tableName);
+    alloc.setTxnIds(txnIds);
+    AllocateTableWriteIdsResponse writeIds = txnHandler.allocateTableWriteIds(alloc);
+    assertEquals(3, writeIds.getTxnToWriteIdsSize());
+
+    for (long txnId : txnIds) {
+      txnHandler.commitTxn(new CommitTxnRequest(txnId));
+    }
+
+    // Allow TXN_OPENTXN_TIMEOUT window to expire, then run empty committed cleanup.
+    Thread.sleep(txnHandler.getOpenTxnTimeOutMillis() + 50);
+    txnHandler.setOpenTxnTimeOutMillis(1);
+    txnHandler.cleanEmptyAbortedAndCommittedTxns();
+    txnHandler.setOpenTxnTimeOutMillis(1000);
+
+    GetOpenTxnsResponse openTxns = txnHandler.getOpenTxns();
+    Assert.assertTrue("HWM must remain >= max allocated write txn after TXNS cleanup, got hwm="
+            + openTxns.getTxn_high_water_mark() + " maxTxn=" + maxTxnId,
+        openTxns.getTxn_high_water_mark() >= maxTxnId);
+
+    // Simulate pre-fix cleaner that deleted TXNS rows while TXN_TO_WRITE_ID still has mappings.
+    try (Connection conn = TestTxnDbUtil.getConnection(conf);
+         Statement stmt = conn.createStatement()) {
+      String inList = txnIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+      stmt.executeUpdate("DELETE FROM \"TXNS\" WHERE \"TXN_ID\" IN (" + inList + ")");
+      conn.commit();
+    }
+
+    openTxns = txnHandler.getOpenTxns();
+    Assert.assertTrue("HWM must use TXN_TO_WRITE_ID when TXNS rows are gone, got hwm="
+            + openTxns.getTxn_high_water_mark() + " maxTxn=" + maxTxnId,
+        openTxns.getTxn_high_water_mark() >= maxTxnId);
+
+    GetValidWriteIdsRequest writeIdsReq = new GetValidWriteIdsRequest(
+        Collections.singletonList(TableName.getDbTable(dbName, tableName)));
+    GetValidWriteIdsResponse writeIdsRsp = txnHandler.getValidWriteIds(writeIdsReq);
+    TableValidWriteIds tableWriteIds = writeIdsRsp.getTblValidWriteIds().get(0);
+
+    Assert.assertTrue("Write HWM should reflect allocated write ids, got "
+            + tableWriteIds.getWriteIdHighWaterMark(),
+        tableWriteIds.getWriteIdHighWaterMark() >= 3);
+    // Collapsed bad snapshot is writeHwm=1, minOpen=1, invalid=[1] → ":1:1:1:"
+    Assert.assertFalse("Must not treat write id 1 as the only open write after cleanup",
+        tableWriteIds.getWriteIdHighWaterMark() == 1
+            && tableWriteIds.isSetMinOpenWriteId()
+            && tableWriteIds.getMinOpenWriteId() == 1
+            && tableWriteIds.getInvalidWriteIdsSize() == 1
+            && tableWriteIds.getInvalidWriteIds().get(0) == 1);
+  }
+
+  /**
+   * OCR-2541: after TXNS rows for committed writers are removed, opening a new txn inside
+   * TXN_OPENTXN_TIMEOUT must not gap-fill those writer ids as open (that yields writeIdList
+   * ...:1:1:1: even when HWM was raised via TXN_TO_WRITE_ID).
+   */
+  @Test
+  public void testOpenTxnGapFillSkipsAllocatedWriters() throws Exception {
+    String dbName = "default";
+    String tableName = "ocr2541_gap";
+
+    OpenTxnsResponse opened = txnHandler.openTxns(new OpenTxnRequest(3, "me", "localhost"));
+    List<Long> writerTxnIds = opened.getTxn_ids();
+    long maxWriterTxn = Collections.max(writerTxnIds);
+
+    AllocateTableWriteIdsRequest alloc = new AllocateTableWriteIdsRequest(dbName, tableName);
+    alloc.setTxnIds(writerTxnIds);
+    assertEquals(3, txnHandler.allocateTableWriteIds(alloc).getTxnToWriteIdsSize());
+
+    for (long txnId : writerTxnIds) {
+      txnHandler.commitTxn(new CommitTxnRequest(txnId));
+    }
+
+    // Remove writer TXNS rows while leaving TXN_TO_WRITE_ID mappings (HWM hole + gap-fill risk).
+    try (Connection conn = TestTxnDbUtil.getConnection(conf);
+         Statement stmt = conn.createStatement()) {
+      String inList = writerTxnIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+      stmt.executeUpdate("DELETE FROM \"TXNS\" WHERE \"TXN_ID\" IN (" + inList + ")");
+      conn.commit();
+    }
+
+    // New open txn within timeout forces gap-fill between remaining TXNS and this id.
+    OpenTxnsResponse readerOpened = txnHandler.openTxns(new OpenTxnRequest(1, "me", "localhost"));
+    long readerTxnId = readerOpened.getTxn_ids().get(0);
+    Assert.assertTrue("Reader txn should be above cleaned writers", readerTxnId > maxWriterTxn);
+
+    GetOpenTxnsResponse openTxns = txnHandler.getOpenTxns();
+    Assert.assertTrue("HWM must cover cleaned writers, got hwm=" + openTxns.getTxn_high_water_mark(),
+        openTxns.getTxn_high_water_mark() >= maxWriterTxn);
+    for (long writerTxnId : writerTxnIds) {
+      Assert.assertFalse("Gap-fill must not mark allocated writer txn " + writerTxnId + " as open",
+          openTxns.getOpen_txns().contains(writerTxnId));
+    }
+
+    GetValidWriteIdsRequest writeIdsReq = new GetValidWriteIdsRequest(
+        Collections.singletonList(TableName.getDbTable(dbName, tableName)));
+    TableValidWriteIds tableWriteIds =
+        txnHandler.getValidWriteIds(writeIdsReq).getTblValidWriteIds().get(0);
+
+    Assert.assertTrue("Write HWM should reflect allocated write ids, got "
+            + tableWriteIds.getWriteIdHighWaterMark(),
+        tableWriteIds.getWriteIdHighWaterMark() >= 3);
+    Assert.assertFalse("Must not collapse to writeIdList ...:1:1:1: after gap-fill",
+        tableWriteIds.getWriteIdHighWaterMark() == 1
+            && tableWriteIds.isSetMinOpenWriteId()
+            && tableWriteIds.getMinOpenWriteId() == 1
+            && tableWriteIds.getInvalidWriteIdsSize() == 1
+            && tableWriteIds.getInvalidWriteIds().get(0) == 1);
+
+    txnHandler.abortTxn(new AbortTxnRequest(readerTxnId));
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MetricsConstants.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/MetricsConstants.java
@@ -82,6 +82,13 @@ public class MetricsConstants {
   public static final String TOTAL_NUM_ABORTED_TXNS = "total_num_aborted_transactions";
   public static final String TOTAL_NUM_COMMITTED_TXNS = "total_num_committed_transactions";
   public static final String TOTAL_NUM_TIMED_OUT_TXNS = "total_num_timed_out_transactions";
+  /**
+   * Cumulative count of TXNS id gaps that were not invented as OPEN because the txn id is still
+   * present in TXN_TO_WRITE_ID / COMPLETED_TXN_COMPONENTS (empty-TXNS cleanup race). Elevated
+   * rate can indicate aggressive cleaner / empty committed cleanup patterns.
+   */
+  public static final String TOTAL_NUM_OPEN_TXN_GAP_FILL_SKIPPED =
+      "total_num_open_txn_gap_fill_skipped";
 
   public static final String OPEN_CONNECTIONS = "open_connections";
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -239,14 +239,17 @@ class CompactionTxnHandler extends TxnHandler {
     LOG.info("Start to clean empty aborted or committed TXNS");
     //after that, so READ COMMITTED is sufficient.
     /*
-     * Only delete aborted / committed transaction in a way that guarantees two things:
+     * Only delete aborted / committed transaction in a way that guarantees:
      * 1. never deletes anything that is inside the TXN_OPENTXN_TIMEOUT window
      * 2. never deletes the maximum txnId even if it is before the TXN_OPENTXN_TIMEOUT window
+     * 3. never deletes a txn still mapped in TXN_TO_WRITE_ID (OCR-2541: removing those rows
+     *    lets open-txn HWM fall below committed writers and hide ACID data from readers)
      */
     try {
       long lowWaterMark = jdbcResource.execute(new OpenTxnTimeoutLowBoundaryTxnIdHandler(openTxnTimeOutMillis));
       jdbcResource.execute(
           "DELETE FROM \"TXNS\" WHERE \"TXN_ID\" NOT IN (SELECT \"TC_TXNID\" FROM \"TXN_COMPONENTS\") " +
+              "AND NOT EXISTS (SELECT 1 FROM \"TXN_TO_WRITE_ID\" WHERE \"T2W_TXNID\" = \"TXNS\".\"TXN_ID\") " +
               "AND (\"TXN_STATE\" = :abortedState OR \"TXN_STATE\" = :committedState) AND \"TXN_ID\" < :txnId",
           new MapSqlParameterSource()
               .addValue("txnId", lowWaterMark)

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetHighWaterMarkHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetHighWaterMarkHandler.java
@@ -29,10 +29,18 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class GetHighWaterMarkHandler implements QueryHandler<Long> {
-  
+
+  /**
+   * Highest txn id known to have been allocated/committed, even if the corresponding row was
+   * already removed from {@code TXNS} by empty-txn cleanup (OCR-2541 / HIVE-23048 HWM regression).
+   */
   @Override
   public String getParameterizedQueryString(DatabaseProduct databaseProduct) throws MetaException {
-    return "SELECT MAX(\"TXN_ID\") FROM \"TXNS\"";
+    return "SELECT MAX(hwm) FROM ("
+        + "SELECT MAX(\"TXN_ID\") AS hwm FROM \"TXNS\" "
+        + "UNION ALL SELECT MAX(\"T2W_TXNID\") FROM \"TXN_TO_WRITE_ID\" "
+        + "UNION ALL SELECT MAX(\"CTC_TXNID\") FROM \"COMPLETED_TXN_COMPONENTS\""
+        + ") t";
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetOpenTxnsListHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetOpenTxnsListHandler.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hive.metastore.txn.jdbc.queries;
 import org.apache.hadoop.hive.metastore.DatabaseProduct;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.TxnType;
+import org.apache.hadoop.hive.metastore.metrics.Metrics;
+import org.apache.hadoop.hive.metastore.metrics.MetricsConstants;
 import org.apache.hadoop.hive.metastore.txn.entities.OpenTxn;
 import org.apache.hadoop.hive.metastore.txn.entities.OpenTxnList;
 import org.apache.hadoop.hive.metastore.txn.entities.TxnStatus;
@@ -111,6 +113,7 @@ public class GetOpenTxnsListHandler implements QueryHandler<OpenTxnList> {
 
     long hwm = 0;
     long openTxnLowBoundary = 0;
+    long skippedAllocated = 0;
     List<OpenTxn> txnInfos = new ArrayList<>();
     // OCR-2541: pre-load allocated txn ids so gap-fill does not treat cleaned writers as open.
     Set<Long> knownAllocated = getAllKnownAllocatedTxnIds(dbConn);
@@ -128,6 +131,7 @@ public class GetOpenTxnsListHandler implements QueryHandler<OpenTxnList> {
             LOG.debug("Open transaction added for missing value in TXNS {}",
                 JavaUtils.txnIdToString(openTxnLowBoundary));
           } else {
+            skippedAllocated++;
             LOG.debug("Skipping gap fill for allocated txn {}",
                 JavaUtils.txnIdToString(openTxnLowBoundary));
           }
@@ -153,8 +157,12 @@ public class GetOpenTxnsListHandler implements QueryHandler<OpenTxnList> {
     // that still exist in TXN_TO_WRITE_ID / COMPLETED_TXN_COMPONENTS. Raise HWM so readers do
     // not treat those committed write ids as open/invalid.
     hwm = Math.max(hwm, getAllocatedTxnHighWaterMark(dbConn));
-    LOG.info("Got OpenTxnList with hwm: {} and openTxnList size {} (knownAllocated={}).",
-        hwm, txnInfos.size(), knownAllocated.size());
+    if (skippedAllocated > 0) {
+      Metrics.getOrCreateCounter(MetricsConstants.TOTAL_NUM_OPEN_TXN_GAP_FILL_SKIPPED)
+          .inc(skippedAllocated);
+    }
+    LOG.info("Got OpenTxnList with hwm: {} and openTxnList size {} (knownAllocated={}, skippedAllocated={}).",
+        hwm, txnInfos.size(), knownAllocated.size(), skippedAllocated);
     return new OpenTxnList(hwm, txnInfos);
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetOpenTxnsListHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetOpenTxnsListHandler.java
@@ -31,10 +31,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class GetOpenTxnsListHandler implements QueryHandler<OpenTxnList> {
 
@@ -84,43 +88,124 @@ public class GetOpenTxnsListHandler implements QueryHandler<OpenTxnList> {
      * If there is a pending openTxns, that is already acquired it's sequenceId but not yet committed the insert
      * into the TXNS table, will have either a lower txn_id than HWM and will be listed in the openTxn list,
      * or will have a higher txn_id and don't effect this getOpenTxns() call.
+     *
+     * Materialize TXNS rows first so follow-up lookups against TXN_TO_WRITE_ID / COMPLETED_TXN_COMPONENTS
+     * do not run while this ResultSet is still open (MySQL JDBC cannot safely multiplex nested queries).
      */
+    Connection dbConn = rs.getStatement().getConnection();
+    List<TxnRow> rows = new ArrayList<>();
+    while (rs.next()) {
+      TxnRow row = new TxnRow();
+      row.txnId = rs.getLong(1);
+      row.state = TxnStatus.fromString(rs.getString(2));
+      row.txnType = TxnType.findByValue(rs.getInt(3));
+      row.age = rs.getLong(4);
+      if (infoFields) {
+        row.user = rs.getString(5);
+        row.host = rs.getString(6);
+        row.startedTime = rs.getLong(7);
+        row.lastHeartBeatTime = rs.getLong(8);
+      }
+      rows.add(row);
+    }
+
     long hwm = 0;
     long openTxnLowBoundary = 0;
     List<OpenTxn> txnInfos = new ArrayList<>();
+    // OCR-2541: pre-load allocated txn ids so gap-fill does not treat cleaned writers as open.
+    Set<Long> knownAllocated = getAllKnownAllocatedTxnIds(dbConn);
 
-    while (rs.next()) {
-      long txnId = rs.getLong(1);
-      long age = rs.getLong(4);
+    for (TxnRow row : rows) {
+      long txnId = row.txnId;
       hwm = txnId;
-      if (age < openTxnTimeOutMillis) {
+      if (row.age < openTxnTimeOutMillis) {
         // We will consider every gap as an open transaction from the previous txnId
+        // unless that txn id is already known allocated via write-id / completed components.
         openTxnLowBoundary++;
         while (txnId > openTxnLowBoundary) {
-          // Add an empty open transaction for every missing value
-          txnInfos.add(new OpenTxn(openTxnLowBoundary, TxnStatus.OPEN, TxnType.DEFAULT));
-          LOG.debug("Open transaction added for missing value in TXNS {}",
-              JavaUtils.txnIdToString(openTxnLowBoundary));
+          if (!knownAllocated.contains(openTxnLowBoundary)) {
+            txnInfos.add(new OpenTxn(openTxnLowBoundary, TxnStatus.OPEN, TxnType.DEFAULT));
+            LOG.debug("Open transaction added for missing value in TXNS {}",
+                JavaUtils.txnIdToString(openTxnLowBoundary));
+          } else {
+            LOG.debug("Skipping gap fill for allocated txn {}",
+                JavaUtils.txnIdToString(openTxnLowBoundary));
+          }
           openTxnLowBoundary++;
         }
       } else {
         openTxnLowBoundary = txnId;
       }
-      TxnStatus state = TxnStatus.fromString(rs.getString(2));
-      if (state == TxnStatus.COMMITTED) {
+      if (row.state == TxnStatus.COMMITTED) {
         // This is only here, to avoid adding this txnId as possible gap
         continue;
       }
-      OpenTxn txnInfo = new OpenTxn(txnId, state, TxnType.findByValue(rs.getInt(3)));
+      OpenTxn txnInfo = new OpenTxn(txnId, row.state, row.txnType);
       if (infoFields) {
-        txnInfo.setUser(rs.getString(5));
-        txnInfo.setHost(rs.getString(6));
-        txnInfo.setStartedTime(rs.getLong(7));
-        txnInfo.setLastHeartBeatTime(rs.getLong(8));
+        txnInfo.setUser(row.user);
+        txnInfo.setHost(row.host);
+        txnInfo.setStartedTime(row.startedTime);
+        txnInfo.setLastHeartBeatTime(row.lastHeartBeatTime);
       }
       txnInfos.add(txnInfo);
     }
-    LOG.debug("Got OpenTxnList with hwm: {} and openTxnList size {}.", hwm, txnInfos.size());
+    // OCR-2541: empty committed/aborted TXNS cleanup can drop MAX(TXNS) below writer txn ids
+    // that still exist in TXN_TO_WRITE_ID / COMPLETED_TXN_COMPONENTS. Raise HWM so readers do
+    // not treat those committed write ids as open/invalid.
+    hwm = Math.max(hwm, getAllocatedTxnHighWaterMark(dbConn));
+    LOG.info("Got OpenTxnList with hwm: {} and openTxnList size {} (knownAllocated={}).",
+        hwm, txnInfos.size(), knownAllocated.size());
     return new OpenTxnList(hwm, txnInfos);
+  }
+
+  private Set<Long> getAllKnownAllocatedTxnIds(Connection dbConn) throws SQLException {
+    Set<Long> known = new HashSet<>();
+    String[] queries = new String[] {
+        "SELECT \"T2W_TXNID\" FROM \"TXN_TO_WRITE_ID\"",
+        "SELECT \"CTC_TXNID\" FROM \"COMPLETED_TXN_COMPONENTS\""
+    };
+    try (Statement stmt = dbConn.createStatement()) {
+      for (String query : queries) {
+        try (ResultSet ids = stmt.executeQuery(query)) {
+          while (ids.next()) {
+            known.add(ids.getLong(1));
+          }
+        }
+      }
+    }
+    return known;
+  }
+
+  private long getAllocatedTxnHighWaterMark(Connection dbConn) throws SQLException {
+    long allocatedHwm = 0;
+    String[] queries = new String[] {
+        "SELECT MAX(\"TXN_ID\") FROM \"TXNS\"",
+        "SELECT MAX(\"T2W_TXNID\") FROM \"TXN_TO_WRITE_ID\"",
+        "SELECT MAX(\"CTC_TXNID\") FROM \"COMPLETED_TXN_COMPONENTS\""
+    };
+    try (Statement hwmStmt = dbConn.createStatement()) {
+      for (String query : queries) {
+        try (ResultSet hwmRs = hwmStmt.executeQuery(query)) {
+          if (hwmRs.next()) {
+            long value = hwmRs.getLong(1);
+            if (!hwmRs.wasNull()) {
+              allocatedHwm = Math.max(allocatedHwm, value);
+            }
+          }
+        }
+      }
+    }
+    return allocatedHwm;
+  }
+
+  private static final class TxnRow {
+    long txnId;
+    TxnStatus state;
+    TxnType txnType;
+    long age;
+    String user;
+    String host;
+    long startedTime;
+    long lastHeartBeatTime;
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetOpenTxnsListHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/queries/GetOpenTxnsListHandler.java
@@ -160,9 +160,11 @@ public class GetOpenTxnsListHandler implements QueryHandler<OpenTxnList> {
 
   private Set<Long> getAllKnownAllocatedTxnIds(Connection dbConn) throws SQLException {
     Set<Long> known = new HashSet<>();
+    // Unquoted identifiers: these helper queries run on a raw JDBC Connection and must work
+    // on MySQL even when session sql_mode lacks ANSI_QUOTES (QueryHandler path quotes separately).
     String[] queries = new String[] {
-        "SELECT \"T2W_TXNID\" FROM \"TXN_TO_WRITE_ID\"",
-        "SELECT \"CTC_TXNID\" FROM \"COMPLETED_TXN_COMPONENTS\""
+        "SELECT T2W_TXNID FROM TXN_TO_WRITE_ID",
+        "SELECT CTC_TXNID FROM COMPLETED_TXN_COMPONENTS"
     };
     try (Statement stmt = dbConn.createStatement()) {
       for (String query : queries) {
@@ -178,10 +180,11 @@ public class GetOpenTxnsListHandler implements QueryHandler<OpenTxnList> {
 
   private long getAllocatedTxnHighWaterMark(Connection dbConn) throws SQLException {
     long allocatedHwm = 0;
+    // Unquoted identifiers — see getAllKnownAllocatedTxnIds().
     String[] queries = new String[] {
-        "SELECT MAX(\"TXN_ID\") FROM \"TXNS\"",
-        "SELECT MAX(\"T2W_TXNID\") FROM \"TXN_TO_WRITE_ID\"",
-        "SELECT MAX(\"CTC_TXNID\") FROM \"COMPLETED_TXN_COMPONENTS\""
+        "SELECT MAX(TXN_ID) FROM TXNS",
+        "SELECT MAX(T2W_TXNID) FROM TXN_TO_WRITE_ID",
+        "SELECT MAX(CTC_TXNID) FROM COMPLETED_TXN_COMPONENTS"
     };
     try (Statement hwmStmt = dbConn.createStatement()) {
       for (String query : queries) {


### PR DESCRIPTION
## Summary
- Fix Hive Metastore open-txn high water mark so it uses `max(TXNS, TXN_TO_WRITE_ID, COMPLETED_TXN_COMPONENTS)` after empty committed/aborted TXNS cleanup (avoids intermittent empty ACID reads / `writeIdList …:1:1:1:`).
- Skip `TXN_OPENTXN_TIMEOUT` gap-fill for txn ids already allocated in T2W/CTC (stops phantom `OpenTxn` lists that drove HMS OOM).
- Keep cleaner from deleting TXNS rows still mapped in `TXN_TO_WRITE_ID`.
- Port OCR-2541 `TestTxnHandler` regression tests for HWM and gap-fill behavior.

## Test plan
- [ ] `TestTxnHandler#testOpenTxnHwmSurvivesEmptyCommittedCleanup`
- [ ] `TestTxnHandler#testOpenTxnGapFillSkipsAllocatedWriters`
- [ ] Review `GetHighWaterMarkHandler` / `GetOpenTxnsListHandler` / `CompactionTxnHandler` changes



Made with [Cursor](https://cursor.com)