### PR TITLE
ODP-7461: Fix metastore schematool init by restoring Apache hive.version.shortname

### DIFF
--- a/standalone-metastore/metastore-common/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetastoreVersionInfo.java
+++ b/standalone-metastore/metastore-common/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetastoreVersionInfo.java
@@ -34,7 +34,11 @@ public class TestMetastoreVersionInfo {
 
   @Test
   public void testValidateHiveShortVersionWithHiveVersion() {
-    Assert.assertEquals(hiveVersion.replace("-SNAPSHOT", ""), hiveShortVersion);
+    // ODP builds append the distribution version (4.1.0.<odp.release.version>), while the short
+    // version stays at the Apache version because it selects the metastore schema scripts.
+    String fullVersion = hiveVersion.replace("-SNAPSHOT", "");
+    Assert.assertTrue("Short version " + hiveShortVersion + " is not in line with " + fullVersion,
+        fullVersion.equals(hiveShortVersion) || fullVersion.startsWith(hiveShortVersion + "."));
   }
 
   @Test

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -47,7 +47,10 @@
   <properties>
     <odp.release.version>3.3.6.5-SNAPSHOT</odp.release.version>
     <hive.version>4.1.0.${odp.release.version}</hive.version>
-    <hive.version.shortname>4.1.0.${odp.release.version}</hive.version.shortname>
+    <!-- Must stay at the Apache base version: it is baked into MetastoreVersionAnnotation
+         and used by MetaStoreSchemaInfo to pick scripts/metastore/upgrade/<db>/hive-schema-<shortname>.<db>.sql
+         and to validate the VERSION table, both of which only know Apache versions. -->
+    <hive.version.shortname>4.1.0</hive.version.shortname>
     <standalone.metastore.path.to.root>.</standalone.metastore.path.to.root>
     <!-- Build properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
.